### PR TITLE
Added null coalescing to prevent PHP 8.1+ from throwing a Deprecated msg for Google Auth

### DIFF
--- a/hybridauth.module
+++ b/hybridauth.module
@@ -967,9 +967,9 @@ function hybridauth_get_provider_config($provider_id) {
   $provider_config = array(
     'enabled' => array_key_exists($provider_id, array_filter($config->get('hybridauth_providers'))),
     'keys' => array(
-      'id' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_id')),
-      'key' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_key')),
-      'secret' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_secret')),
+      'id' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_id') ?? ''),
+      'key' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_key') ?? ''),
+      'secret' => trim($config->get('hybridauth_provider_' . $lowercase_provider_id . '_keys_secret') ?? ''),
     ),
     'scope' => $config->get('hybridauth_provider_' . $lowercase_provider_id . '_scope'),
     'display' => $config->get('hybridauth_provider_' . $lowercase_provider_id . '_display'),


### PR DESCRIPTION
Fixes #18 

This is really simple, but the code was trying to read values from the config that didn't exist, and passing them through the trim() function.

In PHP 8+, this causes a Deprecated message, specifically when using Google Auth and probably a lot of others.  Here you can see my messages I got when signing up to my test site with Google:

<img width="1325" height="145" alt="2025-12-17 11_09_17-Mozilla Firefox" src="https://github.com/user-attachments/assets/92a0fbdd-17fb-4d2c-ae1d-884ebccbae67" />

Anyway, this small change should keep those messages at bay, and retain the functionality of it being an empty string if it didn't exist.